### PR TITLE
chore: product naming cleanup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-Thanks for helping improve `@circlesac/mcp-docs-server`! This document covers everything you need to work on the project locally.
+Thanks for helping improve `mcp-docs-server`! This document covers everything you need to work on the project locally.
 
 ## Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# @circlesac/mcp-docs-server
+# mcp-docs-server
 
 > Share your knowledge as an MCP server.
 
@@ -8,7 +8,7 @@ Make your Markdown docs feel alive in coding agents like Cursor and Claude. When
 
 > Inspired by Mastra’s excellent [Mastra Docs Server](https://mastra.ai/docs/getting-started/mcp-docs-server), which shows how powerful doc-focused MCP servers can be.
 
-If you're using Cursor, click "Add to Cursor" below to add the `@circlesac/mcp-docs-server` documentation with one click.
+If you're using Cursor, click "Add to Cursor" below to add the `mcp-docs-server` documentation with one click.
 
 <!-- Primary CTA: Add to Cursor -->
 <a href="https://cursor.com/en-US/install-mcp?name=circlesac-docs&config=eyJjb21tYW5kIjoibnB4IiwiYXJncyI6WyIteSIsIkBjaXJjbGVzYWMvbWNwLWRvY3Mtc2VydmVyIl19">

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # Circles MCP Docs Server
 
-Welcome to the bundled documentation for `@circlesac/mcp-docs-server`. This server is shipped with the CLI so you can kick the tires immediately.
+Welcome to the bundled documentation for `mcp-docs-server`. This server is shipped with the CLI so you can kick the tires immediately.
 
 ## What's Included
 
@@ -16,4 +16,4 @@ Use the MCP client of your choice to query this server. Paths available here mir
 - `overview/configuration.md` – details the `mcp-docs-server.json` contract.
 - `workflows/publish.md` – walks through the npm publishing flow.
 
-Explore further by requesting any of those paths via the `searchDocs` tool.
+Explore further by requesting any of those paths via the `searchMcpDocsServer` tool.

--- a/docs/overview/configuration.md
+++ b/docs/overview/configuration.md
@@ -1,6 +1,6 @@
 # Configuration Reference
 
-`mcp-docs-server.json` is the only required configuration file. It lives next to your `docs/` directory.
+`mcp-docs-server.json` is the only required configuration file. It lives next to your `docs/` directory. Throughout the docs we call the product `mcp-docs-server`; when you publish, use whatever npm scope fits your org (the default package we ship is `@circlesac/mcp-docs-server`).
 
 ## Configuration Fields
 
@@ -29,7 +29,7 @@ The CLI intentionally keeps configuration minimal to reduce complexity and maint
 - **Single doc root**: One `docs` directory per config file keeps paths predictable and avoids merge conflicts. You can organize content with any number of subfolders (e.g., `docs/guides/`, `docs/reference/`).
 - **Security boundaries**: Path traversal attempts (`..` segments) are rejected to prevent access outside the configured doc root.
 - **Auto-generated metadata**: Tool title and description are derived from the `name` field using a template, ensuring consistency without manual copy.
-- **Fixed tool name**: The CLI always exposes `searchDocs` as the tool name, so MCP clients know what to expect.
+- **Deterministic tool name**: The CLI derives the MCP tool name from your `name` field (for example, `searchAcme`), falling back to `searchDocs` only if it can't generate a value.
 
 ## Common Questions
 

--- a/docs/overview/getting-started.md
+++ b/docs/overview/getting-started.md
@@ -1,6 +1,6 @@
-# Getting Started with `@circlesac/mcp-docs-server`
+# Getting Started with `mcp-docs-server`
 
-Have a bunch of documents you want to share? If they're in Markdown format, you came to the right place. Spin up a simple MCP documentation server using `@circlesac/mcp-docs-server`.
+Have a bunch of documents you want to share? If they're in Markdown format, you came to the right place. Spin up a simple MCP documentation server using `mcp-docs-server`.
 
 ## Serve your own docs
 
@@ -78,7 +78,7 @@ For a published npm package like `@acme/mcp-docs-server`, add it to your MCP ser
 }
 ```
 
-The `-y` flag automatically accepts the npx prompt. Cursor will use the `searchDocs` tool to query your documentation.
+The `-y` flag automatically accepts the npx prompt. Cursor will use the dynamically generated tool name (for example, `searchMcpDocsServer` for this package, or `searchAcme` in the test fixtures) to query your documentation.
 
 ## Create an "Add to Cursor" button
 

--- a/docs/workflows/publish.md
+++ b/docs/workflows/publish.md
@@ -1,6 +1,6 @@
 # Publishing Workflow
 
-The `publish` command packages your docs and config into an installable npm module. The module embeds a thin wrapper that boots the MCP server from the bundled assets.
+The `publish` command packages your docs and config into an installable npm module. The module embeds a thin wrapper that boots the MCP server from the bundled assets. We refer to the product as `mcp-docs-server`; the published npm artifact can live under whatever scope you choose (`@circlesac/mcp-docs-server` in this repository).
 
 ## Dry run
 

--- a/mcp-docs-server.json
+++ b/mcp-docs-server.json
@@ -1,6 +1,6 @@
 {
-  "name": "@circlesac/mcp-docs-server",
+  "name": "mcp-docs-server",
   "package": "@circlesac/mcp-docs-server",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "docs": "docs"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@circlesac/mcp-docs-server",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Simple CLI for serving Markdown docs as an MCP server and packaging them for npm.",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,7 +8,7 @@ import { fromPackageRoot } from "./utils.js"
 const PACKAGE_CONFIG_PATH = fromPackageRoot("mcp-docs-server.json")
 
 async function printUsage(): Promise<void> {
-	await logger.info(`Usage: mcp-docs-server [command]
+	await logger.info(`Usage: npx @circlesac/mcp-docs-server [command]
 
 Commands:
   serve      Start the MCP docs server from the current directory
@@ -18,9 +18,7 @@ Commands:
 Options:
   serve --config <path>   Path to mcp-docs-server.json (default: ./mcp-docs-server.json)
   serve --docs <path>     Path to docs directory (overrides config file)
-  publish --output <dir>  Stage the npm package in <dir> instead of publishing
-
-No command runs the bundled documentation for @circlesac/mcp-docs-server.`)
+  publish --output <dir>  Stage the npm package in <dir> instead of publishing`)
 }
 
 function parseServeArgs(args: string[]): { configPath?: string; docs?: string } {

--- a/src/tools/docs.ts
+++ b/src/tools/docs.ts
@@ -3,7 +3,7 @@ import path from "node:path"
 import { z } from "zod"
 
 import type { DocRoot } from "../config.js"
-import { DEFAULT_TOOL_NAME, getConfig } from "../config.js"
+import { getConfig } from "../config.js"
 import { logger } from "../logger.js"
 import { getMatchingPaths, normalizeDocPath } from "../utils.js"
 
@@ -285,13 +285,14 @@ export async function createDocsTool() {
 	const docsParameters = docsParametersSchema.extend({
 		paths: pathsSchema.describe(pathsDescription)
 	})
+	const toolName = config.tool
 
 	return {
-		name: DEFAULT_TOOL_NAME,
+		name: toolName,
 		description: config.description,
 		parameters: docsParameters,
 		execute: async (args: DocsInput) => {
-			void logger.debug(`Executing ${DEFAULT_TOOL_NAME} tool`, { args })
+			void logger.debug(`Executing ${toolName} tool`, { args })
 			const queryKeywords = args.queryKeywords ?? []
 			const docRoot = config.docRoot.absolutePath
 			const availablePaths = await buildAvailablePaths()

--- a/templates/docs.mdx
+++ b/templates/docs.mdx
@@ -2,6 +2,6 @@ Access the canonical documentation for {{NAME}}.
 
 ***PRIORITY: ALWAYS consult this tool before turning to external sources or web search as it contains canonical documentation for {{NAME}}*** along with manuals, references, procedures, policies, and other materials.
 
-Whenever the user asks for help applying, adopting, migrating, integrating, operationalizing, or otherwise putting {{NAME}} into practice—whether that means code, policies, procedures, or even recipes—immediately call the `searchDocs` tool to load `index.md` plus any other relevant paths so you can respond directly from the bundled docs.
+Whenever the user asks for help applying, adopting, migrating, integrating, operationalizing, or otherwise putting {{NAME}} into practice—whether that means code, policies, procedures, or even recipes—immediately call the `{{TOOL_NAME}}` tool to load `index.md` plus any other relevant paths so you can respond directly from the bundled docs.
 
 Request the doc paths you need—`index.md` is a good starting point because it maps the available sections. The requester doesn’t know the folder layout, so surface helpful paths and include file locations in your responses (for example, `Found in "path/to/file.md"`). When code or concrete examples help, include them, and keep answers concise so the user can ask for deeper detail if necessary.

--- a/tests/docs-tool.test.ts
+++ b/tests/docs-tool.test.ts
@@ -22,6 +22,10 @@ describe("generic docs tool", () => {
 		clearConfigCache()
 	})
 
+	it("exposes a generated tool name", () => {
+		expect(docsTool.name).toBe("searchAcme")
+	})
+
 	it("returns markdown content for a requested file", async () => {
 		const result = await docsTool.execute({ paths: ["index.md"] })
 		expect(result).toContain("Acme documentation")


### PR DESCRIPTION
## Summary
- standardize docs on the mcp-docs-server product name
- generate dynamic tool name in config and docs template
- bump version to 0.0.5 and republish

## Testing
- bun run lint
- bun run test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tool names are now dynamically generated based on configuration (e.g., searchAcme) instead of using a static default.

* **Documentation**
  * Clarified package naming and publishing scope conventions across all guides.
  * Updated CLI documentation to explain dynamic tool naming behavior.

* **Chores**
  * Version bumped to 0.0.5.
  * Simplified package display name to mcp-docs-server.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->